### PR TITLE
Reorient to community

### DIFF
--- a/devent.toml
+++ b/devent.toml
@@ -73,9 +73,9 @@ teams = [
 """
 
 "Who is it for?" = """
-  Participants should be maintainers or core contributors of an IPFS implementation, ranging from production usage to working demo. <KINDLY CLARIFY THAT THIS IS INVITE-ONLY> If this describes you and you haven't received an invitation, please email <@ipfs.io EMAIL ADDRESS THAT MOSH HAS REQUESTED>.
+  This invite-only event brings together maintainers or core contributors of an IPFS implementation, ranging from production usage to working demo. If this describes you and you haven't received an invitation, please email <@ipfs.io EMAIL ADDRESS THAT MOSH HAS REQUESTED>.
   
-  If you are a user, tooling developer, <INSERT MYRIAD OF POSSIBLE ROLES HERE>, or curious community member, we enthusiastically invite you to IPFS Camp, an epic decentralized event organized by the community, for the community. Details coming soon!
+  If you are a user, tooling developer, <INSERT MYRIAD OF POSSIBLE ROLES HERE>, or curious community member, we enthusiastically invite you to IPFS Camp, an epic decentralized event organized by the community, for the community. Details on IPFS camp are coming soon, and will be announced on [twitter](https://twitter.com/ipfs).
 """
 
 "How do I contact the organizers?" = """

--- a/website/components/about.js
+++ b/website/components/about.js
@@ -8,11 +8,11 @@ export default function About({ config }) {
   const faq = (config.faq) || {}
 
 
-  const sponsors = (config.devent.sponsors) || []
-  var sponsorsEl = (
-    <Section title="Sponsors">
+  const teams = (config.devent.teams) || []
+  var teamsEl = (
+    <Section title="Participating Teams">
       <div className="container max-w-8xl mx-auto flex flex-wrap gap-20 justify-center items-center align-middle">
-        {sponsors.map((s) => (
+        {teams.map((s) => (
           <a href={s[1]} target="_blank" alt={s[0]} className="basis-52 h-[100px] inline-block align-middle">
             <img src={s[2]} className="object-contain object-center h-full"/>
           </a>
@@ -20,7 +20,7 @@ export default function About({ config }) {
       </div>
     </Section>
   )
-  if (!(sponsors.length > 0)) sponsorsEl = ""
+  if (!(teams.length > 0)) teamsEl = ""
 
   return (
 <>


### PR DESCRIPTION
@b5 this PR begins the reorientation to community-led event that we discussed in this morning's call, and is ready for review and discussion!

- Renames everything "sponsors" to "teams"
- Adds Number Zero to Participating Teams list
- Updates the first 2 FAQs

There are several placeholders in the FAQs section. I've checked "Allow edits by maintainers" so feel free to edit directly. Up to you on whether to discuss and merge this set of changes, or wait until a more complete FAQ is done.

