### PR TITLE
reserve mornings for talks, afternoons for facilitated discussion

### DIFF
--- a/events/b_2_content-routing-1.toml
+++ b/events/b_2_content-routing-1.toml
@@ -91,24 +91,16 @@ title="Lunch Break"
 [[timeslots]]
 startTime="14:00"
 speakers=[]
-title="Open Slot"
-
-[[timeslots]]
-startTime="14:45"
-speakers=[]
-title="Open Slot"
+title="Discussion 1: Performant Content Routing"
+description="goal: solving for subsecond CID resolution"
 
 [[timeslots]]
 startTime="15:30"
 speakers=[]
-title="Open Slot"
-
-[[timeslots]]
-startTime="16:15"
-speakers=[]
 title="Break"
 
 [[timeslots]]
-startTime="16:30"
+startTime="15:40"
 speakers=[]
-title="Open Slot"
+title="Discussion 2: Performant Content Routing"
+description="goal: solving for subsecond CID resolution"

--- a/events/b_3_content-routing-2.toml
+++ b/events/b_3_content-routing-2.toml
@@ -70,7 +70,7 @@ description="this is a description of the talk!"
 [[timeslots]]
 startTime="10:45"
 speakers=[]
-title="Open Slot"
+title="FHE: Fully Homomorphic Encryption & Content Routing"
 
 [[timeslots]]
 startTime="11:30"
@@ -95,25 +95,16 @@ title="Lunch Break"
 [[timeslots]]
 startTime="14:00"
 speakers=[]
-title="FHE: Fully Homomorphic Encryption & Content Routing"
-
-[[timeslots]]
-startTime="14:45"
-speakers=[]
-title="Open Slot"
+title="Discussion 1: Private Content Routing"
+description="goal: Roadmapping private content routing research"
 
 [[timeslots]]
 startTime="15:30"
 speakers=[]
-title="Open Slot"
-
-[[timeslots]]
-startTime="16:15"
-speakers=[]
 title="Break"
 
 [[timeslots]]
-startTime="16:30"
+startTime="15:40"
 speakers=[]
-title="Open Slot"
-
+title="Discussion 2: Private Content Routing"
+description="goal: Roadmapping private content routing research"

--- a/events/b_4_ipfs-wasm.toml
+++ b/events/b_4_ipfs-wasm.toml
@@ -100,59 +100,28 @@ description=""
 [[timeslots]]
 startTime="12:15"
 speakers=[]
-title="Lunch Break"
+title="Open Slot"
 description=""
 
 [[timeslots]]
 startTime="13:00"
 speakers=[]
-title="Open Slot"
-description=""
-
-[[timeslots]]
-startTime="13:30"
-speakers=[]
-title="Open Slot"
+title="Lunch Break"
 description=""
 
 [[timeslots]]
 startTime="14:00"
 speakers=[]
-title="Open Slot"
-description=""
-
-[[timeslots]]
-startTime="14:30"
-speakers=[]
-title="Open Slot"
-description=""
-
-[[timeslots]]
-startTime="15:00"
-speakers=[]
-title="Break"
+title="Discussion 1: IPFS & WASM"
 description=""
 
 [[timeslots]]
 startTime="15:30"
 speakers=[]
-title="Open Slot"
-description=""
+title="Break"
 
 [[timeslots]]
-startTime="16:00"
+startTime="15:40"
 speakers=[]
-title="Open Slot"
-description=""
-
-[[timeslots]]
-startTime="16:30"
-speakers=[]
-title="Open Slot"
-description=""
-
-[[timeslots]]
-startTime="17:00"
-speakers=[]
-title="Open Slot"
+title="Discussion 2: IPFS & WASM"
 description=""

--- a/events/c_1_ipfs_infra.toml
+++ b/events/c_1_ipfs_infra.toml
@@ -116,29 +116,16 @@ description=""
 [[timeslots]]
 startTime="14:00"
 speakers=[]
-title="Open Slot"
-description=""
-
-[[timeslots]]
-startTime="14:45"
-speakers=[]
-title="Open Slot"
+title="Discussion 1: IPFS Infra"
 description=""
 
 [[timeslots]]
 startTime="15:30"
 speakers=[]
-title="Open Slot"
-description=""
-
-[[timeslots]]
-startTime="16:15"
-speakers=[]
 title="Break"
-description=""
 
 [[timeslots]]
-startTime="16:30"
+startTime="15:40"
 speakers=[]
-title="Open Slot"
+title="Discussion 2: IPFS Infra"
 description=""

--- a/events/c_2_project_and_community.toml
+++ b/events/c_2_project_and_community.toml
@@ -116,29 +116,16 @@ description=""
 [[timeslots]]
 startTime="14:00"
 speakers=[]
-title="Open Slot"
-description=""
-
-[[timeslots]]
-startTime="14:45"
-speakers=[]
-title="Open Slot"
+title="Discussion 1: Project & Community"
 description=""
 
 [[timeslots]]
 startTime="15:30"
 speakers=[]
-title="Open Slot"
-description=""
-
-[[timeslots]]
-startTime="16:15"
-speakers=[]
 title="Break"
-description=""
 
 [[timeslots]]
-startTime="16:30"
+startTime="15:40"
 speakers=[]
-title="Open Slot"
+title="Discussion 2: Project & Community"
 description=""

--- a/events/c_3_data_transfer.toml
+++ b/events/c_3_data_transfer.toml
@@ -116,29 +116,16 @@ description=""
 [[timeslots]]
 startTime="14:00"
 speakers=[]
-title="Open Slot"
-description=""
-
-[[timeslots]]
-startTime="14:45"
-speakers=[]
-title="Open Slot"
+title="Discussion 1: Data Transfer"
 description=""
 
 [[timeslots]]
 startTime="15:30"
 speakers=[]
-title="Open Slot"
-description=""
-
-[[timeslots]]
-startTime="16:15"
-speakers=[]
 title="Break"
-description=""
 
 [[timeslots]]
-startTime="16:30"
+startTime="15:40"
 speakers=[]
-title="Open Slot"
+title="Discussion 2: Data Transfer"
 description=""

--- a/events/d_1_identity_and_access_control copy.toml
+++ b/events/d_1_identity_and_access_control copy.toml
@@ -116,29 +116,16 @@ description=""
 [[timeslots]]
 startTime="14:00"
 speakers=[]
-title="Open Slot"
-description=""
-
-[[timeslots]]
-startTime="14:45"
-speakers=[]
-title="Open Slot"
+title="Discussion 1: Identity & Access Control"
 description=""
 
 [[timeslots]]
 startTime="15:30"
 speakers=[]
-title="Open Slot"
-description=""
-
-[[timeslots]]
-startTime="16:15"
-speakers=[]
 title="Break"
-description=""
 
 [[timeslots]]
-startTime="16:30"
+startTime="15:40"
 speakers=[]
-title="Open Slot"
+title="Discussion 2: Identity & Access Control"
 description=""

--- a/events/d_2_lite_clients.toml
+++ b/events/d_2_lite_clients.toml
@@ -116,29 +116,16 @@ description=""
 [[timeslots]]
 startTime="14:00"
 speakers=[]
-title="Open Slot"
-description=""
-
-[[timeslots]]
-startTime="14:45"
-speakers=[]
-title="Open Slot"
+title="Discussion 1: Lite Clients"
 description=""
 
 [[timeslots]]
 startTime="15:30"
 speakers=[]
-title="Open Slot"
-description=""
-
-[[timeslots]]
-startTime="16:15"
-speakers=[]
 title="Break"
-description=""
 
 [[timeslots]]
-startTime="16:30"
+startTime="15:40"
 speakers=[]
-title="Open Slot"
+title="Discussion 2: Lite Clients"
 description=""

--- a/events/d_3_data_agony.toml
+++ b/events/d_3_data_agony.toml
@@ -116,29 +116,16 @@ description=""
 [[timeslots]]
 startTime="14:00"
 speakers=[]
-title="Open Slot"
-description=""
-
-[[timeslots]]
-startTime="14:45"
-speakers=[]
-title="Open Slot"
+title="Discussion 1: Data Agony & IPFS"
 description=""
 
 [[timeslots]]
 startTime="15:30"
 speakers=[]
-title="Open Slot"
-description=""
-
-[[timeslots]]
-startTime="16:15"
-speakers=[]
 title="Break"
-description=""
 
 [[timeslots]]
-startTime="16:30"
+startTime="15:40"
 speakers=[]
-title="Open Slot"
+title="Discussion 2: Data Agony & IPFS"
 description=""


### PR DESCRIPTION
Based on feedback & suggestions from the IPFS implementer's community call, I'd like to propose we split tracks in half, reserving the morning for prepared talks, and afternoons for facilitated discussion:
<img width="1621" alt="Screen Shot 2022-06-13 at 12 11 43 PM" src="https://user-images.githubusercontent.com/1154390/173397729-a506aa5e-344a-4cb8-852a-f8e50d2dc4fb.png">

