### PR TITLE
fix off by 1 error in date display

### DIFF
--- a/website/components/event.js
+++ b/website/components/event.js
@@ -273,8 +273,12 @@ function bindKey(bindKey, handler) {
 
 function dateStr(date, days) {
   const d1 = dayjs(date)
-  const d2 = dayjs(date).add(days, 'day')
-  return d1.format("MMM DD") +' - '+ d2.format("MMM DD")
+  const d2 = dayjs(date).add(days - 1, 'day')
+  if (days == 1) {
+    return d1
+  } else if (days >= 2) {
+    return d1.format("MMM DD") +' - '+ d2.format("MMM DD")
+  }
 }
 
 export default EventCard

--- a/website/components/event.js
+++ b/website/components/event.js
@@ -273,12 +273,13 @@ function bindKey(bindKey, handler) {
 
 function dateStr(date, days) {
   const d1 = dayjs(date)
-  const d2 = dayjs(date).add(days - 1, 'day')
-  if (days == 1) {
-    return d1
-  } else if (days >= 2) {
-    return d1.format("MMM DD") +' - '+ d2.format("MMM DD")
+
+  if (days === 1) {
+    return d1.format("MMM DD")
   }
+
+  const d2 = d1.add(days - 1, 'day')
+  return d1.format("MMM DD") +' - '+ d2.format("MMM DD")
 }
 
 export default EventCard


### PR DESCRIPTION
This PR fixes the off by 1 error in how dates are displayed in the event card detail. I haven't written production js in many years, so please review the heck out of it (especially syntax).

Here's an example of the error. The metadata for this event only shows 1 day, but it renders as 2 days.
<img width="278" alt="image" src="https://user-images.githubusercontent.com/1306020/173696438-8ebbebc7-7d85-40b8-ab0c-51980b5381c9.png">
