### PR TITLE
highlight track chairs instead of organizations

### DIFF
--- a/website/components/event.js
+++ b/website/components/event.js
@@ -58,7 +58,7 @@ function BlockCard({ event }) {
         👤 {event.attendees} - {event.difficulty}
       </div>
       <div className="text-gray-900 text-sm mt-3">
-        {event.org}
+        {event.dri}
       </div>
 
       <div className="event-tags">
@@ -83,7 +83,7 @@ function TrackCard({ event }) {
         👤 {event.attendees} - {event.difficulty}
       </div>
       <div className="text-gray-900 text-sm mt-3">
-        {event.org}
+        {event.dri}
       </div>
 
       <div className="event-tags">
@@ -133,7 +133,7 @@ export function EventModal({ children, event }) {
               <ul className="list-disc ml-4">
                 <li><b>Date</b>: {dateStr(event.date, event.days)}</li>
                 <li><b>Times</b>: {event.times}</li>
-                <li><b>Organizers</b>: {event.org}</li>
+                <li><b>Track Chair(s)</b>: {event.dri}</li>
                 <li><b>Attendees</b>: {event.attendees} ({event.difficulty})</li>
               </ul>
               <div className="event-tags">


### PR DESCRIPTION
This changes event card display to feature organizers (labelled track chairs) instead of organizations, using the existing `dri` type.

Benefits:
- Submitters & participants can more easily see & contact the relevant track chair(s)
- Highlight the variety of organizers instead of Protocol Labs monolith