### PR TITLE
bugfix: toml parse error: a """ was left behind

### DIFF
--- a/devent.toml
+++ b/devent.toml
@@ -36,8 +36,6 @@ org="the IPFS Team"
 # the website of the organizers
 orglink="https://ipfs.io/team/"
 
-"""
-
 # url for this event repo
 repo="https://github.com/ipfs-shipyard/ipfs-thing-2022"
 


### PR DESCRIPTION
- remove dangling """ 
- fixes compilation & publishing
