### PR TITLE
re-work hero layout

### DIFF
--- a/devent.toml
+++ b/devent.toml
@@ -3,6 +3,9 @@
 # the name of the devent
 name="IPFS þing"
 
+# where the event is happening
+location="Reykjavík, Iceland"
+
 # the dates the devent runs
 dateStart = "2022-07-11"
 dateEnd = "2022-07-17"
@@ -13,7 +16,7 @@ tagline="""
 """
 
 description="""
-Set in the inspiring and otherworldly landscape of Reykjavík, Iceland, IPFS þing is a week-long gathering for the IPFS implementors community. There will be talks, workshops, discussion circles, coworking and hacking time, and more — all focused on advancing IPFS implementations.
+IPFS þing is a week-long gathering for the IPFS implementors community. There will be talks, workshops, discussion circles, hacking time, and more — all focused on advancing IPFS implementations.
 """
 
 

--- a/website/components/hero.js
+++ b/website/components/hero.js
@@ -10,28 +10,29 @@ export default function Hero({config}) {
 <div className="relative overflow-hidden text-gray-300 lg:flex w-full">
 <div className="container lg:flex max-w-8xl mx-auto">
 
-  <div className="w-full sm:p-16 lg:p-5 lg:min-h-[80vh]">
+  <div className="w-full sm:p-8 lg:p-5 lg:min-h-[80vh]">
     <div className="mx-auto min-h-full lg:ml-0 flex flex-col gap-y-3 justify-center">
 
-      <div className="flex lg:w-1/2">
-        <div className='basis-full w-full lg:basis-1/3 lg:mr-3 my-3'>
+      <div className='lg:mt-10'>
+        <div className='w-72 h-72 mx-auto mt-4 lg:w-xs lg:h-xs lg:float-left lg:mr-3'>
           <img src={config.devent.logo} />
         </div>
-        <div className='basis-full lg:basis-2/3'>
-          <div className="mt-4 font-bold text-white py-4 text-6xl sm:text-5xl">
+        <div className='text-center basis-full lg:basis-2/3 lg:text-left lg:pt-8'>
+          <div className="mt-4 font-bold text-white pt-8 pb-2 text-6xl">
             {config.devent.name}
           </div>
-          <div className="text-xl text-white font-medium">
-            {dateRangeStr(config.devent.dateStart, config.devent.dateEnd)}
+          <div className="text-md italic text-white lg:mt-2 my-3 prose leading-7">
+            {config.devent.tagline}
           </div>
         </div>
       </div>
 
-      <div className='basis-1/3 pl-3'>
-        <div className="text-md italic text-white lg:mt-2 my-5 prose leading-7">
-          {config.devent.tagline}
+      <div className='basis-1/3 pl-3 mx-2 mt-5 mb-14 lg:my-5'>
+        <div className="text-2xl text-white font-bold pb-5">
+          {dateRangeStr(config.devent.dateStart, config.devent.dateEnd)}{config.devent.location && ` • ${config.devent.location}`}
         </div>
-        <div className="text-lg text-white lg:mt-2 my-5 prose leading-7">
+
+        <div className="text-lg text-white prose leading-7">
           <ReactMarkdown remarkPlugins={[gfm]}>{config.devent.description}</ReactMarkdown>
         </div>
 
@@ -39,7 +40,8 @@ export default function Hero({config}) {
         <div className="space-x-5 mb-10">
           <a
             href={config.devent.rsvpLink}
-            className="inline-block px-5 py-3 mt-8 text-sm font-medium text-white bg-orange-500 rounded-lg hover:bg-orange-400"
+            type="button"
+            className="inline-block px-5 py-3 mt-8 text-lg font-medium text-white bg-orange-500 hover:bg-orange-400 px-8 py-3 rounded-lg rounded outline-none focus:outline-none mr-1 mb-1 ease-linear transition-all duration-150"
           >
             RSVP
           </a>


### PR DESCRIPTION
re-worked hero component layout for more consistent rendering across size breakpoints:

<img width="1622" alt="Screen Shot 2022-06-15 at 4 58 10 PM" src="https://user-images.githubusercontent.com/1154390/173928087-3d83210c-8fc9-4bab-8cc7-e1b5275a47ba.png">

<img width="562" alt="Screen Shot 2022-06-15 at 4 58 36 PM" src="https://user-images.githubusercontent.com/1154390/173928234-f0788d47-6677-4a49-a1ef-9bc78b4d92d4.png">

