### PR TITLE
add wasm-ipld talk

### DIFF
--- a/events/b_4_ipfs-wasm.toml
+++ b/events/b_4_ipfs-wasm.toml
@@ -81,9 +81,9 @@ description=""
 
 [[timeslots]]
 startTime="10:00"
-speakers=[]
-title="Open Slot"
-description=""
+speakers=["@adin"]
+title="wasm-ipld demo and discussion"
+description="We have wasm-ipld code that can run in kubo and work with gateways. Let's chat about it and what comes next"
 
 [[timeslots]]
 startTime="10:45"


### PR DESCRIPTION
If I want to add links or resources for the talk should that live in the description or elsewhere?

Note: Probably fine moving later in the day too if this slot was being reserved, but figured filling top down except when there's a conflict seemed reasonable.