### PR TITLE
Add zig-libp2p talk

### DIFF
--- a/events/d_2_lite_clients.toml
+++ b/events/d_2_lite_clients.toml
@@ -79,9 +79,22 @@ description=""
 
 [[timeslots]]
 startTime="10:00"
-speakers=[]
-title="Open Slot"
-description=""
+speakers=["@marcopolo"]
+title="zig-libp2p, a minimal libp2p implementation"
+description="""
+Zig is a general-purpose programming language and toolchain for maintaining
+robust, optimal and reusable software. (from ziglang.org)
+
+Introducing zig-libp2p. A minimal library for using libp2p.
+Usable from Zig, C, or any other language with C FFI.
+Designed to have a small footprint and be performant.
+
+In this talk we'll cover:
+1. Why Zig
+2. Performance benchmarks
+3. Example walkthough
+4. Code walkthrough
+"""
 
 [[timeslots]]
 startTime="10:45"


### PR DESCRIPTION
Add a talk for zig-libp2p to the lite clients event.

I think this is the best spot for it but I'm not sure. Let me know if there's a better spot.

I'm happy to move the time around as well.

also, a word of warning, zig-libp2p is not fully ready yet, but progress has been going well and I expect it to be ready by althing. Worst case this becomes a "How to to fail to build your own libp2p implementation" :P.
