### PR TITLE
add a talk on github-mgmt to project and community track

### DIFF
--- a/events/c_3_project_and_community.toml
+++ b/events/c_3_project_and_community.toml
@@ -60,7 +60,7 @@ Currently, we have reserved a 1/2 day for this track. If enough sessions are pro
 #  speakers    - array of string speaker names. please to use consistent naming across timeslots
 #  title       - string for talk or timeslot title, should be short
 #  description - string describing the timeslot. 1-3 sentences.
-# 
+#
 # Notes:
 # - recommended start: 09:00
 # - recommended lunch: 12:00 or 13:00
@@ -81,9 +81,9 @@ description="A walkthrough of the new RFC process and its motivations, updated s
 
 [[timeslots]]
 startTime="09:45"
-speakers=[]
-title="Open Slot"
-description=""
+speakers=["@galargh"]
+title="GitHub Management"
+description="A high-level overview of how GitHub permissions are managed as code in the IPFS org - https://github.com/ipfs/github-mgmt - and how to leverage it for issuing access requests."
 
 [[timeslots]]
 startTime="10:15"

--- a/events/c_3_project_and_community.toml
+++ b/events/c_3_project_and_community.toml
@@ -82,8 +82,8 @@ description="A walkthrough of the new RFC process and its motivations, updated s
 [[timeslots]]
 startTime="09:45"
 speakers=["@galargh"]
-title="GitHub Management"
-description="A high-level overview of how GitHub permissions are managed as code in the IPFS org - https://github.com/ipfs/github-mgmt - and how to leverage it for issuing access requests."
+title="GitHub Configuration (of IPFS organization) as Code"
+description="This session will be a walk through how PL manages IPFS GitHub organization configuration as code using a tool called GitHub Management. It'll provide practical information on how to request changes to the configuration (for example, if you contribute frequently to a repository within IPFS and you'd want to become a collaborator) and how to set up a similar solution in any other GitHub organization."
 
 [[timeslots]]
 startTime="10:15"


### PR DESCRIPTION
I'd like to add a talk on [GitHub Management](https://github.com/protocol/github-mgmt-template) and, in particular, how we use it in [ipfs org](https://github.com/ipfs/github-mgmt) to the project and community track.

I'd like the main outcomes of the talk to be:
- users know how to request access to ipfs GitHub resources
- users know of GitHub Management and know where to find more information about it if they want to use it in other OS orgs

FYI, I'm not set on this time slot, I picked the first one that was available. 