### PR TITLE
Add writable gateways talk to ipfs as infra track

### DIFF
--- a/events/c_1_connecting-ipfs.toml
+++ b/events/c_1_connecting-ipfs.toml
@@ -107,9 +107,9 @@ description=""
 
 [[timeslots]]
 startTime="13:00"
-speakers=[]
+speakers=["@RangerMauve"]
 title="Writeable Gateways Discussion"
-description=""
+description="This talk will look at the existing state of writable gateways and some potential paths for making them useful for browsers and applications in general"
 
 [[timeslots]]
 startTime="14:00"


### PR DESCRIPTION
We'll be talking about the existing state of writable gateways, work on standardizing writable gateways, and some of the use cases for them in browsers and applications.

Related: https://github.com/AgregoreWeb/agregore-ipfs-daemon/issues/10