### PR TITLE
Update social outing days to make clear nothing specific announced yet

### DIFF
--- a/events/outing11.toml
+++ b/events/outing11.toml
@@ -1,5 +1,5 @@
 # the name of your event
-name = "Outing: Golden Circle"
+name = "Social Outings"
 
 # the name of the group organizing the event
 org = "Protocol Labs"
@@ -22,7 +22,7 @@ days = 1
 times = "10:00 - 19:00"
 
 # the event venue name (will show up on the event card - TODO)
-venueName = "Golden Circle"
+venueName = "(announcing soon)"
 
 # the event venue address (will show up on a map -- TODO)
 venueAddress = ""
@@ -39,7 +39,7 @@ difficulty = "All Welcome"
 
 # tags for the event, will show up as labels.
 # pick 1-4
-tags = ["Outing"]
+tags = ["Outing", "WIP"]
 
 # a color, to group key events visually. use sparingly
 color="slate"
@@ -47,13 +47,7 @@ color="slate"
 # a description of the event.
 # will show up when the user clicks the event card.
 description = """
-Field trip to the Golden Circle:
-
-- þingvellir
-- Geysir
-- Gulfoss
-- Seljalandfoss
-- Skogafoss
+Field trips - announced soon!
 
 Be prepared for the weather! Bring jackets.
 """


### PR DESCRIPTION
Updating schedule around 11th/17th both being outing days, but no details announced yet. Right now makes the schedule looks like only outing is Golden Circle on 11th. We can add deets back in once Yuni locks it down.