### PR TITLE
Gateways and Companion/Desktop remix

### DIFF
--- a/events/b_1_ipfs-impls.toml
+++ b/events/b_1_ipfs-impls.toml
@@ -80,19 +80,19 @@ description=""
 [[timeslots]]
 startTime="13:30"
 speakers=["@adin?"]
-title="go-ipfs"
+title="Kubo (go-ipfs)"
 description=""
 
 [[timeslots]]
 startTime="13:45"
 speakers=["@lidel"]
 title="IPFS Gateways"
-description="Gateways in the past, present, and future"
+description="Gateways in the past, present, and the future"
 
 [[timeslots]]
 startTime="14:00"
 speakers=["@lidel"]
-title="Companion/Desktop, Brave"
+title="IPFS Companion, IPFS Desktop, and Brave"
 description="Bringing IPFS to the end user"
 
 [[timeslots]]
@@ -111,7 +111,7 @@ description="Introducing Iroh: Performant IPFS for the whole world, right now"
 startTime="14:45"
 speakers=["@hsanjuan"]
 title="IPFS Cluster"
-description="IPFS Cluster is an P2P application that uses the go-ipfs menu with some spices on top"
+description="IPFS Cluster is an P2P application that uses the kubo (go-ipfs) menu with some spices on top"
 
 [[timeslots]]
 startTime="15:00"

--- a/events/b_1_ipfs-impls.toml
+++ b/events/b_1_ipfs-impls.toml
@@ -85,15 +85,15 @@ description=""
 
 [[timeslots]]
 startTime="13:45"
-speakers=["@lidel?"]
-title="IPFS Companion & IPFS Desktop"
-description=""
+speakers=["@lidel"]
+title="IPFS Gateways"
+description="Gateways in the past, present, and future"
 
 [[timeslots]]
 startTime="14:00"
-speakers=["@gmasgras?"]
-title="IPFS Gateways"
-description=""
+speakers=["@lidel"]
+title="Companion/Desktop, Brave"
+description="Bringing IPFS to the end user"
 
 [[timeslots]]
 startTime="14:15"


### PR DESCRIPTION
I'm taking over Gateway slot (@gmasgras won't be attending).  Since this track is about "IPFS Implementations"  I'll give overview of past, present and future in the context of recently added [HTTP Gateway specs](https://github.com/ipfs/specs/tree/main/http-gateways) and their use (public gws, local nodes used  by Desktop/Brave/Companion/Agregore etc)

I already had Companion/Desktop, so I  swapped the order, as they use Gateways and it makes sense to talk about that first.

cc @autonome @hsanjuan 