### PR TITLE
fix multiline strings in browsers_and_web track

### DIFF
--- a/events/d_3_browsers_and_web.toml
+++ b/events/d_3_browsers_and_web.toml
@@ -81,8 +81,8 @@ Bring your ideas, use-cases, needs and we'll redefine the track as needed before
 startTime="13:00"
 speakers=["@autonome"]
 title="Intro to IPFS in Browsers & the Web"
-description="What's happened so far, who are the players, what's the landscape, 
-what barriers exist, what feature gaps need closing, what to do next."
+description="""What's happened so far, who are the players, what's the landscape, 
+what barriers exist, what feature gaps need closing, what to do next."""
 
 [[timeslots]]
 startTime="13:20"
@@ -94,15 +94,15 @@ description=""
 startTime="13:40"
 speakers=["@RangerMauve?"]
 title="Agregore `fetch()`, a multi-protocol abstraction"
-description="This talk will look at Peer to Peer URLs and how they can be used
-in tandem with HTTP-like APIs within webapps using custom protocol handlers."
+description="""This talk will look at Peer to Peer URLs and how they can be used
+in tandem with HTTP-like APIs within webapps using custom protocol handlers."""
 
 [[timeslots]]
 startTime="14:00"
 speakers=["@fabricedesre"]
 title="IPFS and Content Discovery"
-description="Incumbent Mobile OSes centralize content discovery in their app
-stores. Let's explore how we could change that with IPFS!"
+description="""Incumbent Mobile OSes centralize content discovery in their app
+stores. Let's explore how we could change that with IPFS!"""
 
 [[timeslots]]
 startTime="14:20"
@@ -126,10 +126,10 @@ description=""
 startTime="15:20"
 speakers=[]
 title="Workshop: Define an IPFS Application Model for the Web Platform"
-description="Work as a group to draft an application model for IPFS which 
+description="""Work as a group to draft an application model for IPFS which 
 aligns with web content models and APIs or redefines them as needed - such as
 handling content loaded from a CID, publishing to IPFS directly from web content
-or what an event model for IPFS content might be."
+or what an event model for IPFS content might be."""
 
 [[timeslots]]
 startTime="16:20"
@@ -141,5 +141,5 @@ description="Sprint exercise to identify common user tasks and enumerate possibl
 startTime="17:00"
 speakers=[]
 title="Workshop: Draft an IPFS network architecture plan for native browser integration"
-description="Work as a group to draft a network architecture plan which
-integrates natively in existing web platform implementations
+description="""Work as a group to draft a network architecture plan which
+integrates natively in existing web platform implementations"""


### PR DESCRIPTION
Multline strings in TOML are surrounded in triple quotes: `"""`
cc @autonome 