### PR TITLE
Assign owners to "State of content routing lightning talks"

### DIFF
--- a/events/b_2_content-routing-1.toml
+++ b/events/b_2_content-routing-1.toml
@@ -59,9 +59,9 @@ title="Content Routing Intro: Performance"
 
 [[timeslots]]
 startTime="10:30"
-speakers=["various"]
+speakers=["@guseggert", "@gammazero", "@ajnavarro"]
 title="State of content routing lightning talks"
-description="@TBD on IPFS DHT, @gammazero on Network Indexer, @TBD on Reframe"
+description="@guseggert on IPFS DHT, @gammazero on Network Indexer, @ajnavarro on Reframe"
 
 [[timeslots]]
 startTime="11:00"


### PR DESCRIPTION
I'm hoping future owners of these components in Kubo (@guseggert, @ajnavarro) can take this rather than legacy owner @aschmahmann .