### PR TITLE
Add note for getting CSV dump of talks

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,18 @@ Tracks are a group of sessions with a common theme.
 
 Room allocations at the Harpa are still TBD. Leave it blank for now, we'll try to assign rooms closer to the event.
 
+### CSV dump of talks
+
+To get a dump of talks/speakers for custom analysis, you can:
+1. Install the python version of yq: https://github.com/kislyuk/yq
+  - ``brew install python-yq``
+2. Run a command like ``tomlq -r '.name as $track_name | .date as $track_date | .timeslots[] | [$track_name, $track_date, .startTime, .title, (.speakers | join(" "))] | @csv' *.toml``
+
+The above was gleaned from:
+1. https://stackoverflow.com/a/71290386/16318
+2. https://stackoverflow.com/a/32967407/16318
+3. https://stackoverflow.com/a/38693695/16318
+
 ## Developers
 
 ### What is `devent-website`?


### PR DESCRIPTION
Here's an example of what this looks like

```
$ tomlq -r '.name as $track_name | .date as $track_date | .timeslots[] | [$track_name, $track_date, .startTime, .title, (.speakers | join(" "))] | @csv' b_1_ipfs-impls.toml
"IPFS Implementations","2022-07-12","13:00","IPFS Implementations","@jbenet"
"IPFS Implementations","2022-07-12","13:15","Lessons from putting IPFS in weird places","@dietrich"
"IPFS Implementations","2022-07-12","13:30","Kubo (go-ipfs)","@adin?"
"IPFS Implementations","2022-07-12","13:45","IPFS Gateways","@lidel"
"IPFS Implementations","2022-07-12","14:00","IPFS Companion, IPFS Desktop, and Brave","@lidel"
"IPFS Implementations","2022-07-12","14:15","WebNative File System (WNFS)","@expede @matheus23"
"IPFS Implementations","2022-07-12","14:30","Iroh","@b5"
"IPFS Implementations","2022-07-12","14:45","IPFS Cluster","@hsanjuan"
"IPFS Implementations","2022-07-12","15:00","Break",""
"IPFS Implementations","2022-07-12","15:15","Filecoin: Lotus, Venus, Forest, Fuhon","@jbenet"
"IPFS Implementations","2022-07-12","15:30","Estuary","@why? @cake?"
"IPFS Implementations","2022-07-12","15:45","Web Scale IPFS","@mikeal"
"IPFS Implementations","2022-07-12","16:00","Berty","@manfred?"
"IPFS Implementations","2022-07-12","16:15","IPFS Operator","@cory"
"IPFS Implementations","2022-07-12","16:30","Auspinner","@danieln"
"IPFS Implementations","2022-07-12","16:45","Break",""
"IPFS Implementations","2022-07-12","17:00","Open Slot",""
"IPFS Implementations","2022-07-12","17:15","js-ipfs","@achingbrain"
"IPFS Implementations","2022-07-12","17:30","Open Slot",""
"IPFS Implementations","2022-07-12","17:45","Open Slot",""
"IPFS Implementations","2022-07-12","Break","16:45",""
"IPFS Implementations","2022-07-12","Open Slot","17:00",""
"IPFS Implementations","2022-07-12","js-ipfs","17:15","@achingbrain"
"IPFS Implementations","2022-07-12","Open Slot","17:30",""
"IPFS Implementations","2022-07-12","Open Slot","17:45",""
```