### PR TITLE
Add Webrecorder lightning talk for Browsers and the Web

### DIFF
--- a/events/d_3_browsers_and_web.toml
+++ b/events/d_3_browsers_and_web.toml
@@ -112,6 +112,12 @@ description=""
 
 [[timeslots]]
 startTime="14:40"
+speakers=["@ikreymer"]
+title="Saving the web to IPFS while you browse with Webrecorder tools"
+description="Will provide a quick overview of Webrecorder tools and how they support saving web sites using the browser, from a single page to many TBs of data, and accessing high fidelity web archives from IPFS. Will cover ongoing work, research and challenges."
+
+[[timeslots]]
+startTime="14:50"
 speakers=[]
 title="Open Slot: Lightning talk"
 description=""


### PR DESCRIPTION
Wanted to claim a lightning talk spot for a quick ~10 min overview of Webrecorder tools and our various use cases for IPFS in the browser. If 10 min is too long, can probably get it down to 5 min..