### PR TITLE
prevent text overflow for track DRIs

### DIFF
--- a/website/components/event.js
+++ b/website/components/event.js
@@ -40,7 +40,7 @@ export function EventCard({ event }) {
 
   return (
     <EventModal event={event}>
-      <div className={classNames('w-full', 'h-full', {'opacity-70': isWorkInProgress})}>
+      <div className={classNames('w-full', 'h-full', 'overflow-hidden', {'opacity-70': isWorkInProgress})}>
         {event.timeslots
           ? <TrackCard event={event} />
           : <BlockCard event={event} />
@@ -87,7 +87,7 @@ function TrackCard({ event }) {
       <div>
         👤 {event.attendees} - {event.difficulty}
       </div>
-      <div className="text-gray-900 text-sm mt-3">
+      <div className="text-gray-900 text-sm mt-3 text-ellipsis overflow-hidden">
         {event.dri}
       </div>
 


### PR DESCRIPTION
address an issue that crops up in #102 :
<img width="1624" alt="Screen Shot 2022-07-08 at 10 11 16 AM" src="https://user-images.githubusercontent.com/1154390/178015449-74d1b54d-da15-42b6-8fb9-6e1b61062ea1.png">

