### PR TITLE
Add IPFS Discourse topic "website" links for each track

### DIFF
--- a/events/b_1_ipfs-impls.toml
+++ b/events/b_1_ipfs-impls.toml
@@ -10,7 +10,7 @@ dri = "@jbenet"
 
 # the website of the event
 # make sure to have all the relevant information: dates, venue, program, ticketing (if any), etc.
-website = "https://discuss.ipfs.io/t/2022-07-12-ipfs-implementations/14618"
+website = "https://discuss.ipfs.io/t/2022-07-12-ipfs-implementations/14621"
 
 # the start date of the event
 date = "2022-07-12"

--- a/events/b_1_ipfs-impls.toml
+++ b/events/b_1_ipfs-impls.toml
@@ -10,7 +10,7 @@ dri = "@jbenet"
 
 # the website of the event
 # make sure to have all the relevant information: dates, venue, program, ticketing (if any), etc.
-website = "https://discuss.ipfs.io/t/2022-07-12-ipfs-implementations/14621"
+website = "https://discuss.ipfs.io/t/2022-07-12-ipfs-implementations/14632"
 
 # the start date of the event
 date = "2022-07-12"

--- a/events/b_1_ipfs-impls.toml
+++ b/events/b_1_ipfs-impls.toml
@@ -10,7 +10,7 @@ dri = "@jbenet"
 
 # the website of the event
 # make sure to have all the relevant information: dates, venue, program, ticketing (if any), etc.
-# website = "https://ipfs-althing.io"
+website = "https://discuss.ipfs.io/t/2022-07-12-ipfs-implementations/14618"
 
 # the start date of the event
 date = "2022-07-12"

--- a/events/b_2_content-routing-1.toml
+++ b/events/b_2_content-routing-1.toml
@@ -10,7 +10,7 @@ dri = "@jbenet" # @willscott
 
 # the website of the event
 # make sure to have all the relevant information: dates, venue, program, ticketing (if any), etc.
-website = "https://discuss.ipfs.io/t/2022-07-13-content-routing-1-performance/14622"
+website = "https://discuss.ipfs.io/t/2022-07-13-content-routing-1-performance/14633"
 
 # the start date of the event
 date = "2022-07-13"

--- a/events/b_2_content-routing-1.toml
+++ b/events/b_2_content-routing-1.toml
@@ -10,7 +10,7 @@ dri = "@jbenet" # @willscott
 
 # the website of the event
 # make sure to have all the relevant information: dates, venue, program, ticketing (if any), etc.
-# website = ""
+website = "https://discuss.ipfs.io/t/2022-07-13-content-routing-1-performance/14622"
 
 # the start date of the event
 date = "2022-07-13"

--- a/events/b_3_content-routing-2.toml
+++ b/events/b_3_content-routing-2.toml
@@ -10,7 +10,7 @@ dri = "@willscott"
 
 # the website of the event
 # make sure to have all the relevant information: dates, venue, program, ticketing (if any), etc.
-# website = ""
+website = "https://discuss.ipfs.io/t/2022-07-14-content-routing-2-privacy/14623"
 
 # the start date of the event
 date = "2022-07-14"

--- a/events/b_3_content-routing-2.toml
+++ b/events/b_3_content-routing-2.toml
@@ -10,7 +10,7 @@ dri = "@willscott"
 
 # the website of the event
 # make sure to have all the relevant information: dates, venue, program, ticketing (if any), etc.
-website = "https://discuss.ipfs.io/t/2022-07-14-content-routing-2-privacy/14623"
+website = "https://discuss.ipfs.io/t/2022-07-14-content-routing-2-privacy/14634"
 
 # the start date of the event
 date = "2022-07-14"

--- a/events/c_1_data_and_ipfs-1.toml
+++ b/events/c_1_data_and_ipfs-1.toml
@@ -10,7 +10,7 @@ dri = "@aschmahmann"
 
 # the website of the event
 # make sure to have all the relevant information: dates, venue, program, ticketing (if any), etc.
-website = ""
+website = "https://discuss.ipfs.io/t/2022-07-13-data-and-ipfs-models/14635"
 
 # the start date of the event
 date = "2022-07-13"

--- a/events/c_2_data_and_ipfs-2.toml
+++ b/events/c_2_data_and_ipfs-2.toml
@@ -10,7 +10,7 @@ dri = "@hannahhoward"
 
 # the website of the event
 # make sure to have all the relevant information: dates, venue, program, ticketing (if any), etc.
-website = "https://ipfs-althing.io"
+website = "https://discuss.ipfs.io/t/2022-07-14-data-and-ipfs-transfer/14636"
 
 # the start date of the event
 date = "2022-07-14"

--- a/events/c_3_project_and_community.toml
+++ b/events/c_3_project_and_community.toml
@@ -10,7 +10,7 @@ dri = "@mishmosh"
 
 # the website of the event
 # make sure to have all the relevant information: dates, venue, program, ticketing (if any), etc.
-website = "https://ipfs-althing.io"
+website = "https://discuss.ipfs.io/t/2022-07-15-project-community/14637"
 
 # the start date of the event
 date = "2022-07-15"

--- a/events/c_4_scalable-virtual-worlds.md
+++ b/events/c_4_scalable-virtual-worlds.md
@@ -10,7 +10,7 @@ dri = "@jbenet"
 
 # the website of the event
 # make sure to have all the relevant information: dates, venue, program, ticketing (if any), etc.
-# website = ""
+website = "https://discuss.ipfs.io/t/2022-07-16-scalable-virtual-worlds/14638"
 
 # the start date of the event
 date = "2022-07-16"

--- a/events/d_1_connecting-ipfs.toml
+++ b/events/d_1_connecting-ipfs.toml
@@ -10,7 +10,7 @@ dri = "@mikeal"
 
 # the website of the event
 # make sure to have all the relevant information: dates, venue, program, ticketing (if any), etc.
-website = "https://discuss.ipfs.io/t/2022-07-13-connecting-ipfs/14625"
+website = "https://discuss.ipfs.io/t/2022-07-13-connecting-ipfs/14639"
 
 # the start date of the event
 date = "2022-07-13"

--- a/events/d_1_connecting-ipfs.toml
+++ b/events/d_1_connecting-ipfs.toml
@@ -10,7 +10,7 @@ dri = "@mikeal"
 
 # the website of the event
 # make sure to have all the relevant information: dates, venue, program, ticketing (if any), etc.
-website = "https://ipfs-althing.io"
+website = "https://discuss.ipfs.io/t/2022-07-13-connecting-ipfs/14625"
 
 # the start date of the event
 date = "2022-07-13"

--- a/events/d_2_data_and_ipfs-3.toml
+++ b/events/d_2_data_and_ipfs-3.toml
@@ -10,7 +10,7 @@ dri = "@hannahhoward+@aschmahmann"
 
 # the website of the event
 # make sure to have all the relevant information: dates, venue, program, ticketing (if any), etc.
-website = ""
+website = "https://discuss.ipfs.io/t/2022-07-14-data-and-ipfs-unconf/14640"
 
 # the start date of the event
 date = "2022-07-14"

--- a/events/d_3_browsers_and_web.toml
+++ b/events/d_3_browsers_and_web.toml
@@ -10,7 +10,7 @@ dri = "@autonome"
 
 # the website of the event
 # make sure to have all the relevant information: dates, venue, program, ticketing (if any), etc.
-website = "https://ipfs-althing.io"
+website = "https://discuss.ipfs.io/t/2022-07-15-browsers-and-the-web-platform/14641"
 
 # the start date of the event
 date = "2022-07-15"

--- a/events/d_3_ipfs-wasm.toml
+++ b/events/d_3_ipfs-wasm.toml
@@ -10,7 +10,7 @@ dri = "@jbenet"
 
 # the website of the event
 # make sure to have all the relevant information: dates, venue, program, ticketing (if any), etc.
-website = "https://discuss.ipfs.io/t/2022-07-15-ipfs-wasm/14624"
+website = "https://discuss.ipfs.io/t/2022-07-15-ipfs-wasm/14642"
 
 # the start date of the event
 date = "2022-07-15"

--- a/events/d_3_ipfs-wasm.toml
+++ b/events/d_3_ipfs-wasm.toml
@@ -10,7 +10,7 @@ dri = "@jbenet"
 
 # the website of the event
 # make sure to have all the relevant information: dates, venue, program, ticketing (if any), etc.
-website = "https://protocol.ai/labday"
+website = "https://discuss.ipfs.io/t/2022-07-15-ipfs-wasm/14624"
 
 # the start date of the event
 date = "2022-07-15"

--- a/events/d_3_roadmap.toml
+++ b/events/d_3_roadmap.toml
@@ -10,7 +10,7 @@ dri = "@momack2"
 
 # the website of the event
 # make sure to have all the relevant information: dates, venue, program, ticketing (if any), etc.
-# website = "https://discuss.ipfs.io/t/2022-07-16-roadmapping-next-steps-out-of-the-ipfs-thing/14643"
+website = "https://discuss.ipfs.io/t/2022-07-16-roadmapping-next-steps-out-of-the-ipfs-thing/14643"
 
 # the start date of the event
 date = "2022-07-16"

--- a/events/d_3_roadmap.toml
+++ b/events/d_3_roadmap.toml
@@ -10,7 +10,7 @@ dri = "@momack2"
 
 # the website of the event
 # make sure to have all the relevant information: dates, venue, program, ticketing (if any), etc.
-# website = ""
+# website = "https://discuss.ipfs.io/t/2022-07-16-roadmapping-next-steps-out-of-the-ipfs-thing/14643"
 
 # the start date of the event
 date = "2022-07-16"

--- a/events/e_3_aqua_ipfs.toml
+++ b/events/e_3_aqua_ipfs.toml
@@ -10,7 +10,7 @@ dri = "@evgenyponomarev"
 
 # the website of the event
 # make sure to have all the relevant information: dates, venue, program, ticketing (if any), etc.
-website = "https://ipfs-althing.io"
+website = "https://discuss.ipfs.io/t/2022-07-14-aqua-and-ipfs/14645"
 
 # the start date of the event
 date = "2022-07-14"

--- a/events/e_3_measuring_ipfs.toml
+++ b/events/e_3_measuring_ipfs.toml
@@ -10,7 +10,7 @@ dri = "@yiannisbot"
 
 # the website of the event
 # make sure to have all the relevant information: dates, venue, program, ticketing (if any), etc.
-# website = ""
+website = "https://discuss.ipfs.io/t/2022-07-15-measuring-ipfs/14646"
 
 # the start date of the event
 date = "2022-07-15"


### PR DESCRIPTION
See https://github.com/ipfs-shipyard/ipfs-thing-2022/issues/110 for context

Here are the list of files/tracks/URLs added:

```
b_1_ipfs-impls	🛤 2022-07-12: IPFS Implementations	https://discuss.ipfs.io/t/2022-07-12-ipfs-implementations/14632
b_2_content-routing-1	🛤 2022-07-13: Content Routing 1: Performance	https://discuss.ipfs.io/t/2022-07-13-content-routing-1-performance/14633
b_3_content-routing-2	🛤 2022-07-14: Content Routing 2: Privacy	https://discuss.ipfs.io/t/2022-07-14-content-routing-2-privacy/14634
c_1_data_and_ipfs-1	🛤 2022-07-13: Data and IPFS: Models	https://discuss.ipfs.io/t/2022-07-13-data-and-ipfs-models/14635
c_2_data_and_ipfs-2	🛤 2022-07-14: Data And IPFS: Transfer	https://discuss.ipfs.io/t/2022-07-14-data-and-ipfs-transfer/14636
c_3_project_and_community	🛤 2022-07-15: Project & Community	https://discuss.ipfs.io/t/2022-07-15-project-community/14637
c_4_scalable-virtual-worlds.md	🛤 2022-07-16: Scalable Virtual Worlds	https://discuss.ipfs.io/t/2022-07-16-scalable-virtual-worlds/14638
d_1_connecting-ipfs	🛤 2022-07-13: Connecting IPFS	https://discuss.ipfs.io/t/2022-07-13-connecting-ipfs/14639
d_2_data_and_ipfs-3	🛤 2022-07-14: Data and IPFS: Unconf	https://discuss.ipfs.io/t/2022-07-14-data-and-ipfs-unconf/14640
d_3_browsers_and_web	🛤 2022-07-15: Browsers and The Web Platform	https://discuss.ipfs.io/t/2022-07-15-browsers-and-the-web-platform/14641
d_3_ipfs-wasm	🛤 2022-07-15: IPFS & WASM	https://discuss.ipfs.io/t/2022-07-15-ipfs-wasm/14642
d_3_roadmap	🛤 2022-07-16: Roadmapping Next Steps out of the IPFS þing	https://discuss.ipfs.io/t/2022-07-16-roadmapping-next-steps-out-of-the-ipfs-thing/14643
e_3_aqua_ipfs	🛤 2022-07-14: Aqua and IPFS	https://discuss.ipfs.io/t/2022-07-14-aqua-and-ipfs/14645
e_3_measuring_ipfs	🛤 2022-07-15: Measuring IPFS	https://discuss.ipfs.io/t/2022-07-15-measuring-ipfs/14646
```

This should be squashed into a single commit.