### PR TITLE
feat: Add event modal deep-linking

### DIFF
--- a/website/components/event.js
+++ b/website/components/event.js
@@ -115,10 +115,38 @@ export function BlankCard() {
   )
 }
 
+/**
+ * @see https://github.com/ipfs-shipyard/ipfs-thing-2022/issues/125
+ */
+function getLocationHash () {
+  if (typeof window !== 'undefined') {
+    return window.location.hash
+  }
+}
+
+/**
+ * @see https://github.com/ipfs-shipyard/ipfs-thing-2022/issues/125
+ */
+function setLocationHash (hash) {
+  if (typeof window !== 'undefined') {
+    window.location.hash = hash
+  }
+}
+
 export function EventModal({ children, event }) {
-  const [openModal, setOpenModal] = useState(false);
-  const open = () => setOpenModal(true)
-  const close = () => setOpenModal(false)
+  let defaultOpenState = false
+  if (getLocationHash() === event.hash) {
+    defaultOpenState = true
+  }
+  const [openModal, setOpenModal] = useState(defaultOpenState);
+  const open = () => {
+    setLocationHash(event.hash)
+    setOpenModal(true)
+  }
+  const close = () => {
+    setLocationHash('#')
+    setOpenModal(false)
+  }
   const isOpen = () => openModal === true
 
   bindKey('Escape', close)

--- a/website/components/event.js
+++ b/website/components/event.js
@@ -140,14 +140,32 @@ export function EventModal({ children, event }) {
   }
   const [openModal, setOpenModal] = useState(defaultOpenState);
   const open = () => {
-    setLocationHash(event.hash)
+    if (getLocationHash() !== event.hash) {
+      setLocationHash(event.hash)
+    }
     setOpenModal(true)
   }
   const close = () => {
-    setLocationHash('#')
+    if (getLocationHash() === event.hash) {
+      setLocationHash('#')
+    }
     setOpenModal(false)
   }
   const isOpen = () => openModal === true
+
+  const [hashChangeEventRegistered, setHashChangeEventRegistered] = useState(false);
+  if (typeof window !== 'undefined' && !hashChangeEventRegistered) {
+    window.addEventListener('hashchange', (hashChangeEvent) => {
+      const oldUrlHash = (new URL(hashChangeEvent.oldURL)).hash
+      const newUrlHash = (new URL(hashChangeEvent.newURL)).hash
+      if (newUrlHash === event.hash) {
+        open()
+      } else if (oldUrlHash === event.hash) {
+        close()
+      }
+    })
+    setHashChangeEventRegistered(true)
+  }
 
   bindKey('Escape', close)
 

--- a/website/components/scheduleSection.js
+++ b/website/components/scheduleSection.js
@@ -3,6 +3,7 @@ import ScrollContainer from 'react-indiana-drag-scroll'
 import { ScheduleTable } from "./scheduletable.js"
 import { AddEventModal } from "./event.js"
 import Markdown from './markdown.js'
+import annotateEvents from '../lib/annotateEvents.js'
 
 export default function ScheduleSection({ events, config }) {
   return (
@@ -26,7 +27,7 @@ export default function ScheduleSection({ events, config }) {
           <ScrollContainer className="scroll-container">
             <div className="flex-none min-h-full w-full">
               <div className="content">
-                <ScheduleTable events={events} config={config} />
+                <ScheduleTable events={annotateEvents(events, config)} config={config} />
               </div>
             </div>
           </ScrollContainer>

--- a/website/components/scheduletable.js
+++ b/website/components/scheduletable.js
@@ -1,17 +1,26 @@
 import dayjs from 'dayjs'
 
 import { EventCard, BlankCard } from './event.js'
+import genDates from '../lib/genDates.js'
+import dayOffset from '../lib/dayOffset.js'
+
+function EventCardWrapper({e, i}) {
+  if (!e.isWithinRange) {
+    return null
+  }
+  return (
+    <div className={`col-start-${(e.startDay + 1)} col-end-${(e.startDay + e.days + 1)} shrink-0 h-full auto-rows-fr`}>
+        <EventCard event={e} key={i} />
+    </div>
+  )
+}
 
 export function ScheduleTable({ events, config }) {
   const startDate = dayjs(config.devent.dateStart)
   const endDate = dayjs(config.devent.dateEnd)
 
   const numDays = Number(dayOffset(startDate, endDate) + 1)
-  const arr = Object.values(events)
   const days = genDates(startDate, numDays)
-
-  arr.map((e, i) => e.startDay = dayOffset(startDate, e.date))
-  const eventWithinRange = (e) => (e.startDay >= 0 && e.startDay < numDays)
 
   return (
     <>
@@ -22,12 +31,7 @@ export function ScheduleTable({ events, config }) {
             <p className="flex-1 mx-2 text-right">{d.format('MMM DD')}</p>
           </div>
         ))}
-        {arr.map((e, i) => (
-          eventWithinRange(e) &&
-            <div className={`col-start-${(e.startDay + 1)} col-end-${(e.startDay + e.days + 1)} shrink-0 h-full auto-rows-fr`}>
-              <EventCard event={e} key={i} />
-            </div>
-        ))}
+        {events.map((e, i) => (<EventCardWrapper e={e} i={i} />))}
         <div className={`col-start-1 col-span-${numDays} shrink-0 h-full`}>
           <BlankCard />
         </div>
@@ -57,19 +61,6 @@ export function ScheduleTable({ events, config }) {
       </div>
     </>
   )
-}
-
-function dayOffset(start, date) {
-  return dayjs(date).diff(dayjs(start), 'days')
-}
-
-function genDates(start, numDays) {
-  const days = []
-  const d = dayjs(start)
-  for (var i = 0; i < numDays; i++) {
-    days.push(d.add(i, 'day'))
-  }
-  return days
 }
 
 export default ScheduleTable

--- a/website/components/scheduletable.js
+++ b/website/components/scheduletable.js
@@ -3,6 +3,7 @@ import dayjs from 'dayjs'
 import { EventCard, BlankCard } from './event.js'
 import genDates from '../lib/genDates.js'
 import dayOffset from '../lib/dayOffset.js'
+import Link from 'next/link.js'
 
 function EventCardWrapper({e, i}) {
   if (!e.isWithinRange) {
@@ -10,7 +11,9 @@ function EventCardWrapper({e, i}) {
   }
   return (
     <div className={`col-start-${(e.startDay + 1)} col-end-${(e.startDay + e.days + 1)} shrink-0 h-full auto-rows-fr`}>
-        <EventCard event={e} key={i} />
+        <Link href={`/${e.hash}`} scroll={false}>
+          <EventCard event={e} key={i} />
+        </Link>
     </div>
   )
 }

--- a/website/lib/annotateEvents.js
+++ b/website/lib/annotateEvents.js
@@ -2,6 +2,15 @@ import dayjs from 'dayjs'
 
 import dayOffset from './dayOffset'
 
+/**
+ * Make a url and human friendly string to use for event hashes.
+ * @param {string} eventName
+ * @returns
+ */
+function readableHash(eventName) {
+  return eventName.replace(/[^a-zA-Z0-9þ]/g, ' ').replace(/\s+/g, '-')
+}
+
 export default function annotateEvents(events, config) {
   const startDate = dayjs(config.devent.dateStart)
   const endDate = dayjs(config.devent.dateEnd)
@@ -14,15 +23,14 @@ export default function annotateEvents(events, config) {
         ...events[fileName],
         fileName,
     }
-    // event.fileName = fileName
     event.startDay = dayOffset(startDate, event.date)
     event.isWithinRange = eventWithinRange(event)
-    event.hash = `#${encodeURIComponent(event.name)}`
+    event.hash = `#${readableHash(event.name)}`
 
     // To ensure our event modal hashes are unique we keep a Set of all the hashes
     if (uniqEventHashes.has(event.hash)) {
         // Filename's are always unique
-        event.hash = `#${encodeURIComponent(event.fileName)}`
+        event.hash = `#${readableHash(event.fileName)}`
     }
 
     uniqEventHashes.add(event.hash)

--- a/website/lib/annotateEvents.js
+++ b/website/lib/annotateEvents.js
@@ -1,0 +1,32 @@
+import dayjs from 'dayjs'
+
+import dayOffset from './dayOffset'
+
+export default function annotateEvents(events, config) {
+  const startDate = dayjs(config.devent.dateStart)
+  const endDate = dayjs(config.devent.dateEnd)
+  const numDays = Number(dayOffset(startDate, endDate) + 1)
+  const eventWithinRange = (e) => (e.startDay >= 0 && e.startDay < numDays)
+  const uniqEventHashes = new Set()
+
+  return Object.keys(events).map((fileName, i) => {
+    const event = {
+        ...events[fileName],
+        fileName,
+    }
+    // event.fileName = fileName
+    event.startDay = dayOffset(startDate, event.date)
+    event.isWithinRange = eventWithinRange(event)
+    event.hash = `#${encodeURIComponent(event.name)}`
+
+    // To ensure our event modal hashes are unique we keep a Set of all the hashes
+    if (uniqEventHashes.has(event.hash)) {
+        // Filename's are always unique
+        event.hash = `#${encodeURIComponent(event.fileName)}`
+    }
+
+    uniqEventHashes.add(event.hash)
+
+    return event
+  })
+}

--- a/website/lib/dayOffset.js
+++ b/website/lib/dayOffset.js
@@ -1,0 +1,5 @@
+import dayjs from 'dayjs'
+
+export default function dayOffset(start, date) {
+  return dayjs(date).diff(dayjs(start), 'days')
+}

--- a/website/lib/genDates.js
+++ b/website/lib/genDates.js
@@ -1,0 +1,10 @@
+import dayjs from 'dayjs'
+
+export default function genDates(start, numDays) {
+  const days = []
+  const d = dayjs(start)
+  for (var i = 0; i < numDays; i++) {
+    days.push(d.add(i, 'day'))
+  }
+  return days
+}


### PR DESCRIPTION
### 1. Modals are deeplinked by `encodeURIComponent(event.name)` with a fallback to `encodeURIComponent(event.fileName)` where names are duplicate

![ipfs-thing-deeplinkmodal-modal-via-url](https://user-images.githubusercontent.com/1173416/178529494-fef2ff3f-c16a-4a5e-84a8-ed82af0cac44.gif)

### 2. Modal open/close adds to window history (going forward/back in browser re-opens/closes modals)
![ipfs-thing-deeplinkmodal-modal-via-url-history](https://user-images.githubusercontent.com/1173416/178541052-9f9ac74d-0ba5-4dd5-98c6-6e83611d76b7.gif)

---

If we don't want 2, let me know, I would just need to revert `'feat: modal open/close uses window.history'` 

fixes #125

