### PR TITLE
Converting RSVP link to recap link

### DIFF
--- a/devent.toml
+++ b/devent.toml
@@ -24,7 +24,12 @@ IPFS þing is a week-long gathering for the IPFS implementors community. There w
 link="https://2022.ipfs-thing.io"
 
 # a link to RSVP for the event
-rsvpLink="https://protocollabs.typeform.com/IPFSThing2022"
+# Commentng out since the event is in the past.
+# rsvpLink="https://protocollabs.typeform.com/IPFSThing2022"
+
+# a link to the recap and videos
+# Dependent on https://github.com/ipfs/ipfs-blog/issues/443 first.
+recapLink="https://blog.ipfs.io/FILL_IN"
 
 # a link to a logo image for the event
 logo="ipfs-thing-logo.png"

--- a/devent.toml
+++ b/devent.toml
@@ -29,7 +29,7 @@ link="https://2022.ipfs-thing.io"
 
 # a link to the recap and videos
 # Dependent on https://github.com/ipfs/ipfs-blog/issues/443 first.
-recapLink="https://blog.ipfs.io/FILL_IN"
+recapLink="https://blog.ipfs.io/ipfs-ping-2022-recap/"
 
 # a link to a logo image for the event
 logo="ipfs-thing-logo.png"

--- a/website/components/hero.js
+++ b/website/components/hero.js
@@ -48,6 +48,16 @@ export default function Hero({config}) {
             RSVP
           </a>
         </div>}
+        {config.devent.rsvpLink && 
+        <div className="space-x-5 mb-10">
+          <a
+            href={config.devent.recapLink}
+            type="button"
+            className="inline-block px-5 py-3 mt-8 text-lg font-medium text-white bg-orange-500 hover:bg-orange-400 px-8 py-3 rounded-lg rounded outline-none focus:outline-none mr-1 mb-1 ease-linear transition-all duration-150"
+          >
+            Recap and Videos
+          </a>
+        </div>}
       </div>
 
 

--- a/website/components/hero.js
+++ b/website/components/hero.js
@@ -48,7 +48,7 @@ export default function Hero({config}) {
             RSVP
           </a>
         </div>}
-        {config.devent.rsvpLink && 
+        {config.devent.recapLink && 
         <div className="space-x-5 mb-10">
           <a
             href={config.devent.recapLink}


### PR DESCRIPTION
Remove the recap link.
Instead link to where one can read a recap and watch the videos.

This can't be merged until https://github.com/ipfs/ipfs-blog/issues/443 is addressed.